### PR TITLE
Two fixes for AppEngine 1.5

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,7 +22,7 @@ import os
 import logging
 
 from google.appengine.dist import use_library
-use_library('django', '1.1')
+use_library('django', '1.2')
 
 APP_ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/utils/external/httplib2/__init__.py
+++ b/utils/external/httplib2/__init__.py
@@ -62,7 +62,7 @@ except ImportError:
 try:
     import ssl # python 2.6
     _ssl_wrap_socket = ssl.wrap_socket
-except ImportError:
+except (ImportError, AttributeError):
     def _ssl_wrap_socket(sock, key_file, cert_file):
         ssl_sock = socket.ssl(sock, key_file, cert_file)
         return httplib.FakeSocket(sock, ssl_sock)


### PR DESCRIPTION
I'm not sure if these are completely valid, but I had to make these two fixes in order to run stashboard with App Engine 1.5.3:
- Use App Engine built-in Django 1.2 instead of having to install Django 1.1.
- Catches an AttributeError when importing httplib2 from AppEngine (see http://code.google.com/p/googleappengine/issues/detail?id=5064)
