### PR TITLE
removed using deprecated severity

### DIFF
--- a/stashboard/handlers/site.py
+++ b/stashboard/handlers/site.py
@@ -275,7 +275,7 @@ class ListSummaryHandler(BaseHandler):
                 status = default_status
 
             if service.list and not lists.has_key(service.list.slug) or \
-                lists[service.list.slug]["status"].severity < status.severity:
+                lists[service.list.slug]["status"].name < status.name:
                 lists[service.list.slug] = {"list": service.list, "status": status}
 
         return { "lists": lists.items() }


### PR DESCRIPTION
to prioritization of services in services-lists now used status name instead deprecated status severity
