### PR TITLE
Merge changes to use Python 2.7 runtime.

### DIFF
--- a/stashboard/app.yaml
+++ b/stashboard/app.yaml
@@ -1,7 +1,8 @@
 application: stashboard-hrd
 version: 2
-runtime: python
+runtime: python27
 api_version: 1
+threadsafe: false
 
 derived_file_type:
 - python_precompiled
@@ -9,6 +10,10 @@ derived_file_type:
 builtins:
 - appstats: on
 - remote_api: on
+
+libraries:
+- name: django
+  version: 1.2
 
 handlers:
 - url: /console/.*

--- a/stashboard/appengine_config.py
+++ b/stashboard/appengine_config.py
@@ -5,12 +5,6 @@ logging.info("IMPORTING SETTINGS")
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 
-from google.appengine.dist import use_library
-try:
-    use_library('django', '1.2')
-except:
-    pass
-
 from django.conf import settings
 _ = settings.TEMPLATE_DIRS
 


### PR DESCRIPTION
Google recently announced that no new 2.5 applications would be allowed
on GAE starting Jan 2014.  See here: http://googleappengine.blogspot.com/2013/03/python-25-thanks-for-good-times.html

I've tested these changes using the local SDK and on an application
deployed live in GAE.
