### PR TITLE
Switch to NDB

### DIFF
--- a/stashboard/app.yaml
+++ b/stashboard/app.yaml
@@ -51,11 +51,7 @@ handlers:
 
 - url: .*
   script: main.py
-
-admin_console:
-  pages:
-  - name: Memcache
-    url: /console/memcache
+  login: admin
 
 skip_files: |
  ^(.*/)?(

--- a/stashboard/app.yaml
+++ b/stashboard/app.yaml
@@ -51,7 +51,6 @@ handlers:
 
 - url: .*
   script: main.py
-  login: admin
 
 skip_files: |
  ^(.*/)?(

--- a/stashboard/appengine_config.py
+++ b/stashboard/appengine_config.py
@@ -8,6 +8,10 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
 from django.conf import settings
 _ = settings.TEMPLATE_DIRS
 
+appstats_MAX_STACK = 15
+
+appstats_CALC_RPC_COSTS = True
+
 def webapp_add_wsgi_middleware(app):
     from google.appengine.ext.appstats import recording
     app = recording.appstats_wsgi_middleware(app)

--- a/stashboard/handlers/api.py
+++ b/stashboard/handlers/api.py
@@ -94,7 +94,6 @@ class ListsListHandler(restful.Controller):
             return
 
         name = self.request.get('name', default_value=None)
-        slug = self.request.get('slug')
         description = self.request.get('description', default_value=None)
 
         if not name or not description:
@@ -102,7 +101,7 @@ class ListsListHandler(restful.Controller):
                            % (name, description))
             return
 
-        slug = slug or slugify.slugify(name)
+        slug = self.request.get('slug') or slugify.slugify(name)
         existing_s = List.get_by_slug(slug)
 
         if existing_s:
@@ -220,7 +219,7 @@ class ServicesListHandler(restful.Controller):
             self.error(400, "Bad list slug: %s" % slist)
             return
 
-        slug = slugify.slugify(name)
+        slug = self.request.get('slug') or slugify.slugify(name)
         existing_s = Service.get_by_slug(slug)
 
         if existing_s:

--- a/stashboard/handlers/api.py
+++ b/stashboard/handlers/api.py
@@ -61,8 +61,6 @@ def invalidate_cache():
                 logging.error("Memcache delete failed on %s", page)
     if not memcache.delete("__all_pages__"):
         logging.error("Memcache delete failed on __all_pages__")
-    taskqueue.add(url='/', method="GET")
-
 
 def aware_to_naive(d):
     """Convert an aware date to an naive date, in UTC"""

--- a/stashboard/handlers/site.py
+++ b/stashboard/handlers/site.py
@@ -331,15 +331,15 @@ class ServiceHandler(BaseHandler):
 
         try:
             if day:
-                start_date = date(int(year), int(month), int(day))
+                start_date = datetime(int(year), int(month), int(day))
                 end_date = start_date + timedelta(days=1)
             elif month:
-                start_date = date(int(year), int(month), 1)
+                start_date = datetime(int(year), int(month), 1)
                 days = calendar.monthrange(start_date.year,
                                            start_date.month)[1]
                 end_date = start_date + timedelta(days=days)
             elif year:
-                start_date = date(int(year), 1, 1)
+                start_date = datetime(int(year), 1, 1)
                 end_date = start_date + timedelta(days=365)
             else:
                 start_date = None
@@ -351,7 +351,7 @@ class ServiceHandler(BaseHandler):
         events = service.events
 
         if start_date and end_date:
-            events.filter('start >= ', start_date).filter('start <', end_date)
+            events.filter(Event.start >= start_date).filter(Event.start < end_date)
 
         td = default_template_data()
         td["statuses"] = Status.query().fetch(100)

--- a/stashboard/migrations.py
+++ b/stashboard/migrations.py
@@ -70,7 +70,7 @@ class UpdateStatusMigration(Migration):
     def run(self):
         logging.info("Update each status")
         # For each status
-        for status in Status.all().fetch(100):
+        for status in Status.query().fetch(100):
 
             # Set the status to default
             status.default = False

--- a/stashboard/models.py
+++ b/stashboard/models.py
@@ -145,7 +145,7 @@ class Service(ndb.Model):
     @ndb.tasklet
     def current_event_async(self):
         event = yield self.events.order(-Event.start).fetch_async(1)
-        raise ndb.Return(event[0])
+        raise ndb.Return(event[0] if event else None)
 
     def url(self):
         return "/services/%s" % self.slug

--- a/stashboard/templates/basic/service.html
+++ b/stashboard/templates/basic/service.html
@@ -27,7 +27,7 @@
               <tr>
                 <td>{{ e.start|date:"N j, fA" }}</td>
                 <td class="status highlight">
-                  <img src="/images/status/{{ e.status.image }}.png" alt="{{ e.status.name }}">
+                  <img src="/images/status/{{ e.status.get.image }}.png" alt="{{ e.status.get.name }}">
                 </td>
                 <td>{{ e.message }}</td>
               </tr>

--- a/stashboard/templates/index.html
+++ b/stashboard/templates/index.html
@@ -22,7 +22,7 @@
 	  {% if service.has_issues %}
 	    <img class="information" src="/images/small-information.png" alt="Had Issues"/>
 	  {% endif %}
-	  <img class="sym" src="/images/{{ service.status.image }}" alt="{{ service.status.title }}"/>
+	  <img class="sym" src="/images/{{ service.status.get.image }}" alt="{{ service.status.get.title }}"/>
 	</a>
       </td>
       {% for h in service.history %}

--- a/stashboard/templates/service.html
+++ b/stashboard/templates/service.html
@@ -28,7 +28,7 @@
       <td class="status highlight"><img src="/images/icons/fugue/information.png" alt="Information" /></td>
       <td>{{ e.message }}</td>
       {% else %}
-      <td class="status highlight"><img src="/images/{{ e.status.image }}" alt="{{ e.status.title }}" /></td>
+      <td class="status highlight"><img src="/images/{{ e.status.get.image }}" alt="{{ e.status.get.title }}" /></td>
       <td>{{ e.message }}</td>
       {% endif %}
     </tr>

--- a/stashboard/templates/summary.html
+++ b/stashboard/templates/summary.html
@@ -16,7 +16,7 @@
       </td>
       <td class="status highlight">
 	<a href="{{ l.list.url }}">
-	  <img class="sym" src="/images/{{ l.status.image }}" alt="{{ l.status.title }}"/>
+	  <img class="sym" src="/images/{{ l.status.get.image }}" alt="{{ l.status.get.title }}"/>
 	</a>
       </td>
     {% endfor %}


### PR DESCRIPTION
Improvements to how entities are stored and retrieved.
In AppEngine you can assign an entity an id and retrieve it quick later on by using this id.
This way is way faster and cheaper (money wise) then querying for the entity by slug and returning the first item.
This change break the scheme of the entities, you will need to start from scratch or convert somehow your old entities.

I also converted the project to use NDB which is the next DB API of AppEngine, the project gained by that the auto memcache when retrieving entities (by id) and allow me to use parallel queries in various places (using tasklets). 
