### PR TITLE
Spelling mistake fix

### DIFF
--- a/stashboard/handlers/api.py
+++ b/stashboard/handlers/api.py
@@ -75,7 +75,7 @@ def aware_to_naive(d):
 
 class NotFoundHandler(restful.Controller):
     def get(self):
-        self.error(404, "Can't find resouce")
+        self.error(404, "Can't find resource")
 
 class ListsListHandler(restful.Controller):
 

--- a/stashboard/templates/publicdoc/index.html
+++ b/stashboard/templates/publicdoc/index.html
@@ -18,7 +18,7 @@
   <h3>Client Errors</h3>
   <p>Client errors will have the following structure. 
   <pre><code>{
-    "message": "Can't find resouce",
+    "message": "Can't find resource",
     "code": 404,
     "error": true
 }</pre></code>


### PR DESCRIPTION
This is a super minor fix: changing "Resouce" to "Resource" in an error message (and on the index template, where that message is used as an example).
