### PR TITLE
Fix Twitter API endpoint to use HTTPS; improve logging

### DIFF
--- a/stashboard/handlers/admin.py
+++ b/stashboard/handlers/admin.py
@@ -478,14 +478,14 @@ class EventTweetHandler(webapp.RequestHandler):
 
         try:
             resp, content = client.request(
-                'http://api.twitter.com/1.1/statuses/update.json',
+                'https://api.twitter.com/1.1/statuses/update.json',
                 method='POST',
                 body=urllib.urlencode({'status': '[%s - %s] %s' % (service_name, status_name, message)})
             )
             if resp.status == 200:
                 logging.info('Tweet successful: [%s - %s] %s' % (service_name, status_name, message))
             else:
-                logging.error('Tweet failed: %s' % resp)
+                logging.error('Tweet failed: Response headers: %s; Response content: %s' % (resp, content))
         except socket.timeout:
             logging.error('Unable to post to Twitter API.')
 


### PR DESCRIPTION
I'm surprised this worked before, but updating tweets via the Twitter API now requires SSL.

[Details](https://dev.twitter.com/docs/auth/application-only-auth):

> SSL absolutely required
> 
> This manner of authentication is only secure if SSL is used. Therefore, all requests (both to obtain and use the tokens) must use HTTPS endpoints, which is also a requirement of using API v1.1.
