### PR TITLE
travis.yaml: bump google_appengine zipfile to 1.8.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
 # command to install dependencies
 install:
   - "pip install -r requirements.txt --use-mirrors"
-  - "wget -q http://googleappengine.googlecode.com/files/google_appengine_1.7.5.zip"
-  - "unzip -q google_appengine_1.7.5.zip"
+  - "wget -q http://googleappengine.googlecode.com/files/google_appengine_1.8.9.zip"
+  - "unzip -q google_appengine_1.8.9.zip"
 # command to run tests
 script: 
   - "APPENGINE_SDK=google_appengine python tests/runner.py tests"


### PR DESCRIPTION
This pull request fixes the Python 2.7 Travis build of stashboard by updating the GAE SDK zipfile to its current version, 1.8.9. The previous version now 404's...alas.

You can see a verified successful build for Python 2.7 at https://travis-ci.org/hblanks/stashboard/jobs/18616608
